### PR TITLE
modified json encoding options to prevent string numerics

### DIFF
--- a/src/Util/StringUtils.php
+++ b/src/Util/StringUtils.php
@@ -108,7 +108,7 @@ class StringUtils
     public static function payload2string($payload, JsonMapper $mapper = null)
     {
         if (is_array($payload)) {
-            return json_encode($payload, JSON_UNESCAPED_SLASHES);
+            return json_encode($payload, JSON_UNESCAPED_SLASHES | JSON_NUMERIC_CHECK);
         } elseif (is_string($payload) || null === $payload) {
             if (trim($payload) !== '') {
                 return $payload;


### PR DESCRIPTION
Generated JWEs contained numerics as strings in their payload.
Example:
```
{
  "iss": "https://www.example.com",
  "jti": "322221540100c285edd7ff59e151e3e25f48165227561a502e1e20502654879b",
  "iat": "1747126731",
}
```
`iat` is a string.
This breaks compatibility with some services.